### PR TITLE
Support local-only path modifications

### DIFF
--- a/local/path.local
+++ b/local/path.local
@@ -1,0 +1,6 @@
+#!/bin/sh
+#
+# Local-only path modifications
+#
+# This file is sourced from shell/path, so helper functions like append_to_path
+# can be used here.

--- a/shell/path
+++ b/shell/path
@@ -119,9 +119,6 @@ prepend_to_path "$HOME/.cargo/bin"
 prepend_to_path "$HOME/.local/bin"
 prepend_to_path "$HOME/bin"
 
-# Include current dir on PATH
-PATH=".:$PATH"
-
 export PATH
 
 while async_queue_read_line manpath line; do

--- a/shell/path
+++ b/shell/path
@@ -112,6 +112,9 @@ prepend_to_path "$GOPATH/bin"
 # Include Rust binaries
 prepend_to_path "$HOME/.cargo/bin"
 
+# Include local-only path modifications
+[ -e "$DOTDIR/local/path.local" ] && . "$DOTDIR/local/path.local"
+
 # Include user's local bin folder(s)
 prepend_to_path "$HOME/.local/bin"
 prepend_to_path "$HOME/bin"


### PR DESCRIPTION
Long overdue: support adding directories to the path that are only relevant to the local machine, and should never be committed.